### PR TITLE
🐛 Fix Multiple Examples

### DIFF
--- a/src/dc/sample/PersistentClass.cls
+++ b/src/dc/sample/PersistentClass.cls
@@ -8,6 +8,12 @@ Property Test As %VarString;
 /// Do ##class(dc.sample.PersistentClass).CreateRecord()
 /// $$$OK
 /// </pre>
+/// Another test
+/// <pre>
+/// Set var = 1
+/// Write var
+/// 1
+/// </pre>
 ClassMethod CreateRecord(ByRef id As %Integer) As %Status
 {
     set sc=$$$OK
@@ -19,6 +25,10 @@ ClassMethod CreateRecord(ByRef id As %Integer) As %Status
 }
 
 /// opens the record by id and reads its property
+/// <pre>
+/// W 1
+/// 1
+/// </pre>
 ClassMethod ReadProperty(id As %Integer) As %Status
 {
     Set sc = $$$OK

--- a/src/iris/tripleSlash/Core.cls
+++ b/src/iris/tripleSlash/Core.cls
@@ -112,6 +112,7 @@ Query FindByClass(className As %String) As %SQLQuery [ SqlProc ]
 	Where parent = :className
 	And Abstract = 0
 	And (Description like '%Examples%' OR Description like '%<example>%' OR Description like '%<pre>%')
+    Order By sequenceNumber
 }
 
 Query FindByPackage(packageName As %String) As %SQLQuery [ SqlProc ]
@@ -121,7 +122,7 @@ Query FindByPackage(packageName As %String) As %SQLQuery [ SqlProc ]
 	Where parent %StartsWith :packageName
 	And Abstract = 0
 	And (Description like '%Examples%' OR Description like '%<example>%' OR Description like '%<pre>%')
-    Group By Parent
+    Order By Parent, sequenceNumber
 }
 
 ClassMethod BuildTestClass(className As %String, Output testClass As %Dictionary.ClassDefinition)

--- a/src/iris/tripleSlash/Parser.cls
+++ b/src/iris/tripleSlash/Parser.cls
@@ -1,18 +1,6 @@
 Class iris.tripleSlash.Parser Extends %RegisteredObject
 {
 
-Parameter exampleOpen = "<example>";
-
-Parameter exampleClose = "</example>";
-
-Parameter exampleSub = 11;
-
-Parameter preOpen = "<pre>";
-
-Parameter preClose = "</pre>";
-
-Parameter preSub = 7;
-
 Parameter BL = {$Char(13,10)};
 
 ClassMethod GetCodeBlock(pBlock As %String, Output codeBlock As %ListOfDataTypes) As %Status
@@ -20,15 +8,12 @@ ClassMethod GetCodeBlock(pBlock As %String, Output codeBlock As %ListOfDataTypes
 	Set tSC = $$$OK
     Set codeBlock = ##class(%ListOfDataTypes).%New()
 	Try {
-        For tag=1:1:2 {
-            Set block = ..ExtractContent(tag, pBlock)
-            Continue:(block="")
-            Set lstBlock = $ListFromString(block, ..#BL)
-            Set pos = 0
-            While $ListNext(lstBlock, pos, value) {
-                Continue:(value="")
-                Do codeBlock.Insert(value)
-            }
+        Set block = ..ExtractContent(1, pBlock)
+        Set lstBlock = $ListFromString(block, ..#BL)
+        Set pos = 0
+        While $ListNext(lstBlock, pos, value) {
+            Continue:(value="")
+            Do codeBlock.Insert(value)
         }
 
 	} Catch tException {
@@ -39,16 +24,18 @@ ClassMethod GetCodeBlock(pBlock As %String, Output codeBlock As %ListOfDataTypes
 
 ClassMethod ExtractContent(tag As %Integer, block As %String) As %String [ Private ]
 {
-    Set tagOpen = ..#exampleOpen
-    Set tagClose = ..#exampleClose
-    Set sub = ..#exampleSub
-    If (tag = 2) {
-        Set tagOpen = ..#preOpen
-        Set tagClose = ..#preClose
-        Set sub = ..#preSub
-
+    Set content = ""
+    Set block = $Replace(block, $Char(13,10), "\n")
+    Set regexClean=##class(%Regex.Matcher).%New("(i?)(<(example|pre)>)|(<\/(example|pre)>)")                             
+    Set matcher=##class(%Regex.Matcher).%New("(i?)<(example|pre)>.*?<\/(example|pre)>")                             
+    Set matcher.Text = block
+    While matcher.Locate() {
+        Set regexClean.Text = matcher.Group
+        Set content = content _ regexClean.ReplaceAll("")
+        Set regexClean.Text = ""
     }
-    Quit $Extract(block, $Find(block, tagOpen), $Find(block, tagClose) - sub)
+    Set content = $Replace(content, "\n", $Char(13,10))
+    Return content
 }
 
 ClassMethod RemoveComments(ByRef pValue As %String) As %Status

--- a/tests/iris/tripleSlash/unittests/TestParser.cls
+++ b/tests/iris/tripleSlash/unittests/TestParser.cls
@@ -138,4 +138,20 @@ Method TestAssertNotEqual()
     Do $$$AssertEquals(block, tExpected, block _ " | " _ tExpected)
 }
 
+Method TestGetMultipleCodeBlock()
+{
+    Set block = "Documentation Test"_$Char(13,10)_"<pre>"_$Char(13,10)_
+        "Write 1"_$Char(13,10)_"; 1"_$Char(13,10)_"</pre>"_
+        "Dont get this line"_$Char(13,10)_"</pre>"_
+        "<example>"_$Char(13,10)_
+        "Write 3"_$Char(13,10)_"3"_$Char(13,10)_"</example>"
+    Do $$$AssertStatusOK(##class(iris.tripleSlash.Parser).GetCodeBlock(block, .codeBlock))
+    Set tExpected = 4
+    Set tResults = codeBlock.Count()
+	Do $$$AssertEquals(tResults, tExpected, tExpected_" = "_tResults)
+    Do $$$AssertStatusOK(##class(iris.tripleSlash.Parser).ListToStr(codeBlock, .tResults))
+    Set tExpected = "Write 1"_$C(13,10)_ "; 1"_$C(13,10)_"Write 3"_$C(13,10)_ "3"
+	Do $$$AssertEquals(tResults, tExpected, tExpected_" = "_tResults)
+}
+
 }


### PR DESCRIPTION
Hello everyone,

In order to Fix multiples comments tests cases,

Refactored the methods:
* ExtractContent - To use Regex instead $Find
* GetCodeBlock - To get multiple code blocks

Fix the FindByPackage removing unecessary GroupBy clause